### PR TITLE
Fixed bug with pick command

### DIFF
--- a/src/main/java/com/godson/kekbot/commands/fun/Pick.java
+++ b/src/main/java/com/godson/kekbot/commands/fun/Pick.java
@@ -18,23 +18,28 @@ public class Pick {
             .withDescription("Has KekBot pick ")
             .withUsage("{p}pick <option> | <option> {can continue adding more options by seperating them with | }")
             .onExecuted(context -> {
+                String noChoicesGiven = "You haven't given me any choices, though...";
+
                 String rawSplit[] = context.getMessage().getRawContent().split(" ", 2);
                 TextChannel channel = context.getTextChannel();
-                if (rawSplit.length > 1) {
-                    List<String> toFormat = Arrays.asList(rawSplit[1].split("\\u007c"));
-                    List<String> choices = new ArrayList<>();
-                    for (String string : toFormat) {
-                        String choice = KekBot.removeWhitespaceEdges(string);
-                        if (!choice.equals("")) choices.add(choice);
-                    }
-                    if (choices.size() > 1) {
-                        Random random = new Random();
-                        channel.sendMessage(KekBot.respond(context, Action.CHOICE_MADE, choices.get(random.nextInt(choices.size())))).queue();
-                    } else {
-                        channel.sendMessage("Well, I guess I'm choosing `" + choices.get(0) + "`, since you haven't given me anything else to pick...").queue();
-                    }
+                if (rawSplit.length <= 1) {
+                    channel.sendMessage(noChoicesGiven).queue();
+                    return;
+                }
+
+                List<String> toFormat = Arrays.asList(rawSplit[1].split("\\u007c"));
+                List<String> choices = new ArrayList<>();
+                for (String string : toFormat) {
+                    String choice = KekBot.removeWhitespaceEdges(string);
+                    if (!choice.equals("")) choices.add(choice);
+                }
+                if (choices.size() > 1) {
+                    Random random = new Random();
+                    channel.sendMessage(KekBot.respond(context, Action.CHOICE_MADE, choices.get(random.nextInt(choices.size())))).queue();
+                } else if (choices.size() == 1) {
+                    channel.sendMessage("Well, I guess I'm choosing `" + choices.get(0) + "`, since you haven't given me anything else to pick...").queue();
                 } else {
-                    channel.sendMessage("You haven't given me any choices, though...").queue();
+                    channel.sendMessage(noChoicesGiven).queue();
                 }
             });
 }


### PR DESCRIPTION
Fixed a bug where `choices.get(0)` was attempted to be used when `choices.size()` was 1 **or 0**, causing the bot to just not respond to the command if the latter. (And presumably throw an error.)  `choices.size()` can be 0 if all the choices were invalid according to the for loop above.