### PR TITLE
Make pick cmd more user friendly

### DIFF
--- a/src/main/java/com/godson/kekbot/commands/fun/Pick.java
+++ b/src/main/java/com/godson/kekbot/commands/fun/Pick.java
@@ -13,12 +13,12 @@ import java.util.Random;
 
 public class Pick {
     /**
-     * Removes "or " from the last element of coll.
+     * Removes "or " from the last element of list.
      */
-    protected static Collection<String> stripOr(Collection<String> coll) {
-        int lastIndex = coll.size() - 1;
-        coll[lastIndex] = coll[lastIndex].replace("^or ", "");
-        return coll;
+    protected static List<String> stripOr(List<String> list) {
+        int lastIndex = list.size() - 1;
+        list.get(lastIndex) = list.get(lastIndex).replace("^or ", "");
+        return list;
     }
 
     protected static List<String> prepareChoices(String choicesString, String splitOn) {

--- a/src/main/java/com/godson/kekbot/commands/fun/Pick.java
+++ b/src/main/java/com/godson/kekbot/commands/fun/Pick.java
@@ -18,23 +18,28 @@ public class Pick {
             .withDescription("Has KekBot pick ")
             .withUsage("{p}pick <option> | <option> {can continue adding more options by seperating them with | }")
             .onExecuted(context -> {
+                String noChoicesGiven = "You haven't given me any choices, though...";
+
                 String rawSplit[] = context.getMessage().getRawContent().split(" ", 2);
                 TextChannel channel = context.getTextChannel();
-                if (rawSplit.length > 1) {
-                    List<String> toFormat = Arrays.asList(rawSplit[1].split("\\u007c"));
-                    List<String> choices = new ArrayList<>();
-                    for (String string : toFormat) {
-                        String choice = KekBot.removeWhitespaceEdges(string);
-                        if (!choice.equals("")) choices.add(choice);
-                    }
-                    if (choices.size() > 1) {
-                        Random random = new Random();
-                        channel.sendMessage(KekBot.respond(context, Action.CHOICE_MADE, choices.get(random.nextInt(choices.size())))).queue();
-                    } else {
-                        channel.sendMessage("Well, I guess I'm choosing `" + choices.get(0) + "`, since you haven't given me anything else to pick...").queue();
-                    }
+                if (rawSplit.length <= 1) {
+                    channel.sendMessage(noChoicesGiven).queue();
+                    return;
+                }
+
+                List<String> toFormat = Arrays.asList(rawSplit[1].split("\\u007c"));
+                List<String> choices = new ArrayList<>();
+                for (String string : toFormat) {
+                    String choice = KekBot.removeWhitespaceEdges(string);
+                    if (!choice.equals("")) choices.add(choice);
+                }
+                if (choices.size() > 1) {
+                    Random random = new Random();
+                    channel.sendMessage(KekBot.respond(context, Action.CHOICE_MADE, choices.get(random.nextInt(choices.size())))).queue();
+                } else if (choices.size() == 1) {
+                    channel.sendMessage("Well, I guess I'm choosing `" + choices.get(0) + "`, since you haven't given me anything else to pick...").queue();
                 } else {
-                    channel.sendMessage("You haven't given me any choices, though...").queue();
+                    channel.sendMessage(noChoicesGiven).queue();
                 }
             });
 }

--- a/src/main/java/com/godson/kekbot/commands/fun/Pick.java
+++ b/src/main/java/com/godson/kekbot/commands/fun/Pick.java
@@ -12,11 +12,40 @@ import java.util.List;
 import java.util.Random;
 
 public class Pick {
+    /**
+     * Removes "or " from the last element of coll.
+     */
+    protected static Collection<String> stripOr(Collection<String> coll) {
+        int lastIndex = coll.size() - 1;
+        coll[lastIndex] = coll[lastIndex].replace("^or ", "");
+        return coll;
+    }
+
+    protected static List<String> prepareChoices(String choicesString, String splitOn) {
+        return Arrays.stream(choicesString.split(splitOn))
+            .map(c -> KekBot.removeWhitespaceEdges(c))
+            .filter(c -> !c.isEmpty())
+            .collect(Collectors.toList());
+    }
+
+    protected static List<String> parseChoices(String choicesString) {
+        List<String> choices = Pick.prepareChoices(choicesString, "\\u007c");
+        if (choices.size() == 1) {
+            // choices[0] is obviously the only element
+            choices = choices.contains(",") ?
+                Pick.stripOr(Pick.prepareChoices(choices[0], ",")) :
+                Pick.prepareChoices(choices[0], " ");
+        }
+        return choices;
+    }
+
     public static Command pick = new Command("pick")
             .withAliases("choose", "decide")
             .withCategory(CommandCategory.FUN)
             .withDescription("Has KekBot pick ")
-            .withUsage("{p}pick <option> | <option> {can continue adding more options by seperating them with | }")
+            .withUsage("{p}pick <option> | <option> {can continue adding more options by seperating them with | }\n" +
+                "{p}pick <option>, <option>, [or ]<option> {can continue adding more options by seperating them with a comma}\n" +
+                "{p}pick <option> <option> {can continue adding more options by seperating them with a space}")
             .onExecuted(context -> {
                 String noChoicesGiven = "You haven't given me any choices, though...";
 
@@ -27,17 +56,12 @@ public class Pick {
                     return;
                 }
 
-                List<String> toFormat = Arrays.asList(rawSplit[1].split("\\u007c"));
-                List<String> choices = new ArrayList<>();
-                for (String string : toFormat) {
-                    String choice = KekBot.removeWhitespaceEdges(string);
-                    if (!choice.equals("")) choices.add(choice);
-                }
+                List<String> choices = Pick.parseChoices(rawSplit[1]);
                 if (choices.size() > 1) {
                     Random random = new Random();
                     channel.sendMessage(KekBot.respond(context, Action.CHOICE_MADE, choices.get(random.nextInt(choices.size())))).queue();
                 } else if (choices.size() == 1) {
-                    channel.sendMessage("Well, I guess I'm choosing `" + choices.get(0) + "`, since you haven't given me anything else to pick...").queue();
+                    channel.sendMessage("Well, I guess I'm choosing `" + choices[0] + "`, since you haven't given me anything else to pick...").queue();
                 } else {
                     channel.sendMessage(noChoicesGiven).queue();
                 }


### PR DESCRIPTION
I added additional ways to specify choices for the pick command, to make it more user friendly and intuitive. Now, in addition to being able to separate choices with vertical bars, you can instead separate with commas or spaces. The command automatically determines which you used. (The priority for separators is `|`, `,`, then ` `.) (If you use spaces, of course, you can't have spaces inside your choices.) It even detects if you wrote your choices like "one, two, or three", stripping the "or" from the last choice.

This PR contains my previous bugfix as well.

(I based this command off of the one in my selfbot, here: https://github.com/tech6hutch/djs-selfbot-cljs/blob/master/src_cljs/selfbot_cljs/commands/RNG/choose.cljs)